### PR TITLE
[ROCm] Use AITER fused_ar_rms API and refine use_1stage heuristic

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -44,14 +44,16 @@ class AiterCustomAllreduceProto(Protocol):
     @contextmanager
     def capture(self): ...
     def close(self) -> None: ...
-    def custom_fused_ar_rms(
+    def fused_ar_rms(
         self,
-        input: torch.Tensor,
-        residual_inp: torch.Tensor,
-        weight: torch.Tensor,
+        inp: torch.Tensor,
+        res_inp: torch.Tensor,
+        *,
+        w: torch.Tensor,
         eps: float,
-        use_1stage: bool,
-    ) -> tuple[torch.Tensor, torch.Tensor] | None: ...
+        registered: bool = False,
+        use_1stage: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]: ...
     def should_custom_ar(self, inp: torch.Tensor) -> bool: ...
 
 
@@ -706,7 +708,7 @@ def _rocm_aiter_fused_allreduce_rmsnorm_impl(
     total_bytes = input_.numel() * input_.element_size()
     hidden_dim = input_.shape[-1]
     token_num = input_.shape[0]
-    hidden_ok = hidden_dim in (512, 1024, 2048, 4096)
+    hidden_ok = hidden_dim in (512, 1024, 2048, 4096, 7168)
     token_ok = token_num <= 80
     world_size = aiter_ar.world_size
     full_nvlink = aiter_ar.fully_connected
@@ -714,14 +716,19 @@ def _rocm_aiter_fused_allreduce_rmsnorm_impl(
     if world_size == 2:
         size_ok = True
     elif full_nvlink and world_size <= 4:
-        size_ok = total_bytes < 160 * 1024
+        size_ok = total_bytes < 256 * 1024
     elif full_nvlink and world_size <= 8:
-        size_ok = total_bytes < 80 * 1024
+        size_ok = total_bytes < 128 * 1024
     else:
         size_ok = False
 
     use_1stage = hidden_ok and token_ok and size_ok
-    result = aiter_ar.custom_fused_ar_rms(input_, residual, weight, epsilon, use_1stage)
+
+    result = aiter_ar.fused_ar_rms(
+        input_, residual,
+        w=weight, eps=epsilon,
+        registered=torch.cuda.is_current_stream_capturing(), use_1stage=use_1stage,
+    )
     assert result is not None
     return result[0], result[1]
 

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1030,6 +1030,44 @@ class RocmAiterAllReduceFusionPass(VllmPatternMatcherPass):
             logger.warning("AITER allreduce fusion must be initialized")
             return
 
+        # Aiter's fused_allreduce_rmsnorm kernel dispatches on hidden_dim.
+        # Before aiter v0.1.12 the launcher was template-specialized on
+        # HIDDEN_DIM and only instantiated for {512, 1024, 2048, 4096}; for any
+        # other hidden_dim all three fallback paths (1-stage, 2-stage, split)
+        # hit the `default:` branch and silently skip the launch, producing
+        # garbage output. See the DISPATCH_AR_FUSION_KERNEL macro in aiter
+        # v0.1.10.post3:
+        # https://github.com/ROCm/aiter/blob/6a0e7b26ccf33164785531212cc2ec2cde0b9243/csrc/include/custom_all_reduce.cuh#L2590
+        # From v0.1.12 onward `hidden_dim` became a runtime argument so any
+        # multiple of the pack size works. Detect the older API surface via
+        # the absence of the managed-buffer `_pool` attribute (introduced
+        # alongside the agnostic kernel) and disable this fusion pass for
+        # unsupported hidden sizes, so the original unfused
+        # allreduce + rms_norm subgraph stays in place.
+        aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
+        _AITER_OLD_FUSED_AR_RMS_HIDDEN = (512, 1024, 2048, 4096)
+        if (
+            aiter_ar is not None
+            and not hasattr(aiter_ar, "_pool")
+            and hidden_dim not in _AITER_OLD_FUSED_AR_RMS_HIDDEN
+        ):
+            logger.warning_once(
+                "AITER allreduce-rmsnorm fusion disabled: aiter<0.1.12 "
+                "only supports hidden_dim in %s; got %d. Upgrade aiter to "
+                ">=0.1.12 to enable fusion for this model.",
+                _AITER_OLD_FUSED_AR_RMS_HIDDEN,
+                hidden_dim,
+            )
+            # Tear down the aiter custom-allreduce created by
+            # `initialize_aiter_allreduce()` above; otherwise its IPC handles
+            # stay registered on the TP group for the server lifetime and
+            # race with the vllm `ca_comm` used by the unfused allreduce
+            # path, corrupting allreduce results (logit collapse / all-`!`
+            # output on Kimi-K2 reproducer).
+            with contextlib.suppress(Exception):
+                rocm_aiter_ops.destroy_aiter_allreduce()
+            return
+
         max_token_num = (max_size / 2) // (hidden_dim * element_size)
         self.max_token_num = min(
             max_token_num,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1031,19 +1031,11 @@ class RocmAiterAllReduceFusionPass(VllmPatternMatcherPass):
             return
 
         # Aiter's fused_allreduce_rmsnorm kernel dispatches on hidden_dim.
-        # Before aiter v0.1.12 the launcher was template-specialized on
-        # HIDDEN_DIM and only instantiated for {512, 1024, 2048, 4096}; for any
-        # other hidden_dim all three fallback paths (1-stage, 2-stage, split)
-        # hit the `default:` branch and silently skip the launch, producing
-        # garbage output. See the DISPATCH_AR_FUSION_KERNEL macro in aiter
-        # v0.1.10.post3:
-        # https://github.com/ROCm/aiter/blob/6a0e7b26ccf33164785531212cc2ec2cde0b9243/csrc/include/custom_all_reduce.cuh#L2590
-        # From v0.1.12 onward `hidden_dim` became a runtime argument so any
-        # multiple of the pack size works. Detect the older API surface via
-        # the absence of the managed-buffer `_pool` attribute (introduced
-        # alongside the agnostic kernel) and disable this fusion pass for
-        # unsupported hidden sizes, so the original unfused
-        # allreduce + rms_norm subgraph stays in place.
+        # Before aiter v0.1.12 the launcher was template-specialized on HIDDEN_DIM
+        # and silently no-op'd for sizes outside {512, 1024, 2048, 4096}. From v0.1.12
+        # hidden_dim is a runtime argument. Detect the older API via the missing
+        # `_pool` attribute and skip fusion for unsupported sizes.
+        # Ref (old kernel): https://github.com/ROCm/aiter/blob/6a0e7b26ccf33164785531212cc2ec2cde0b9243/csrc/include/custom_all_reduce.cuh#L2590
         aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
         _AITER_OLD_FUSED_AR_RMS_HIDDEN = (512, 1024, 2048, 4096)
         if (
@@ -1058,12 +1050,8 @@ class RocmAiterAllReduceFusionPass(VllmPatternMatcherPass):
                 _AITER_OLD_FUSED_AR_RMS_HIDDEN,
                 hidden_dim,
             )
-            # Tear down the aiter custom-allreduce created by
-            # `initialize_aiter_allreduce()` above; otherwise its IPC handles
-            # stay registered on the TP group for the server lifetime and
-            # race with the vllm `ca_comm` used by the unfused allreduce
-            # path, corrupting allreduce results (logit collapse / all-`!`
-            # output on Kimi-K2 reproducer).
+            # Tear down aiter's custom-allreduce so its IPC handles don't
+            # race with vllm's ca_comm on the unfused fallback path.
             with contextlib.suppress(Exception):
                 rocm_aiter_ops.destroy_aiter_allreduce()
             return


### PR DESCRIPTION
## Summary

- Migrate from the deprecated `custom_fused_ar_rms` to the newer
  `fused_ar_rms` keyword-based API in AITER.
- Add `hidden_dim=7168` to the supported dimensions for the 1-stage
  allreduce+RMSNorm kernel.
- Refine `use_1stage` size thresholds based on profiling data
  (256 KB for TP ≤ 4, 128 KB for TP ≤ 8).
- Pass `registered=is_capturing` so AITER manages IPC buffers during
  CUDA-graph capture.

## Motivation — `use_1stage` heuristic

Benchmarking fused allreduce+RMSNorm on TP 4 (hidden_dim=7168, bf16)
shows that the 1-stage kernel is faster up to concurrency 16, after
which the 2-stage kernel wins:

| Concurrency | 1-stage (µs) | 2-stage (µs) | 2-stage / 1-stage |
|:-----------:|:------------:|:------------:|:-----------------:|
|      4      |     5.3      |     8.4      |       1.58        |
|      8      |     6.0      |     8.7      |       1.45        |
|     16      |     7.6      |     9.3      |       1.22        |
|     32      |    11.6      |    11.1      |       0.96        |
|     64      |    19.5      |    15.3      |       0.78        |

The crossover falls between concurrency 16 and 32. The byte threshold
that gates 1-stage for TP ≤ 4 is derived from:

    total_bytes = token_num × hidden_dim × element_size
               = 16 × 7168 × 2 = 224 KB < 256 KB  ✓

so `size_ok = total_bytes < 256 KB` ensures 1-stage is used up to
conc16 for the largest supported hidden_dim.

For TP ≤ 8 a more conservative threshold of 128 KB is applied, since
allreduce cost increases with world_size.

## vllm & aiter version
aiter: 0.1.12.post2.dev29+gb633fba1c
aiter commit: b633fba1c
vllm: 0.19.1rc1.dev83+g83d09d36b.d20260413.rocm700
vllm commit: 83d09d36b5951a8de5205438d0742768ad191c4d

## Accuracy
No fusion:
<img width="1259" height="276" alt="ACC_no_fusion" src="https://github.com/user-attachments/assets/acb2ea8e-96ad-4475-a4a5-08f158d9f818" />

With fusion:
<img width="1329" height="226" alt="ACC_allred_fusion" src="https://github.com/user-attachments/assets/f2c7ef72-6799-455c-b4bc-94cf4a1b3adb" />

## Performance 
Kimi-K2-Thinking-MXFP4 TP=4


| CONC | ISL/OSL | baseline | allreduce | speedup |
|------|---------|----------|-----------|---------|
| 4    | 1k1k    | 197      | 203       | 1.03    |
| 8    | 1k1k    | 349      | 358       | 1.03    |
| 16   | 1k1k    | 573      | 592       | 1.03    |
| 32   | 1k1k    | 927      | 929       | 1.00    |
| 64   | 1k1k    | 1386     | 1397      | 1.01    |

For higher concurrencies we observe fewer calls meet the 1 stage fused condition and we see less uplift
